### PR TITLE
Fix codeowners to team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-@jrbeverly
+* @Brightspace/oss


### PR DESCRIPTION
Resolve a syntax error with the codeowners (needs wildcard). Additionally move it from @jrbeverly to a team.