### PR TITLE
Rollback to s3 instead of blob

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,9 @@ builds:
     - windows
   goarch:
   - amd64
+archives:
+-
+  format: zip
 checksum:
   name_template: 'checksums.txt'
 changelog:
@@ -23,9 +26,8 @@ release:
   prerelease: auto
   name_template: "v{{.Version}}"
 
-blobs:
+s3:
 -
-  provider: s3
   bucket: tfreg
   folder: "ace/providers/{{.ProjectName}}/{{.Version}}"
   region: "us-east-1"


### PR DESCRIPTION
I was encountering a couple issues when attempting to deploy. The blob storage didn't appear to be reading the `AWS_REGION` environment variable, throwing a MissingRegion exception.

This PR rolls back the goreleaser to using `zip` and `s3` instead of the blob storage.